### PR TITLE
Address Recent Reported Issues

### DIFF
--- a/LambdaApp/Db/ADLambda.template
+++ b/LambdaApp/Db/ADLambda.template
@@ -7,6 +7,12 @@ record(mbbo, "$(P)$(R)ImageMode")
    field(VAL,  "1")
 }
 
+record(mbbi, "$(P)$(R)ImageMode_RBV")
+{
+   field(TWST, "")
+   field(TWVL, "")
+}
+
 record(mbbo, "$(P)$(R)DataType")
 {
 	info(asyn:READBACK, "1")

--- a/LambdaApp/src/ADLambda.cpp
+++ b/LambdaApp/src/ADLambda.cpp
@@ -610,7 +610,6 @@ void ADLambda::waitAcquireThread()
 		
 		this->frames.clear();
 
-		this->setIntegerParam(ADAcquire, 0);
 		this->setIntegerParam(ADStatus, ADStatusReadout);
 		this->callParamCallbacks();
 		
@@ -620,7 +619,8 @@ void ADLambda::waitAcquireThread()
 			epicsThreadSleep(SHORT_TIME); 
 			this->lock();
 		}
-		
+
+		this->setIntegerParam(ADAcquire, 0);
 		this->setIntegerParam(ADStatus, ADStatusIdle);
 		this->callParamCallbacks();
 	}

--- a/LambdaApp/src/ADLambda.cpp
+++ b/LambdaApp/src/ADLambda.cpp
@@ -806,7 +806,7 @@ void ADLambda::acquireThread(int index)
 
 		
 		this->lock();
-			if (! this->hasDecoder)
+			if (this->hasDecoder)
 			{
 				if (bad_frame)
 				{ 


### PR DESCRIPTION
* Ophyd was having problems with ImageMode readback having a different set of values compared to the control PV
* Acquire was changing to 0 too early
* There was inverted logic in handing the frames off to the export thread that could cause a segfault